### PR TITLE
feat: support for variable event modifiers based on event age

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -50,6 +50,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
+    // A channel to communicate events to websocket handler.
+    // Few events like challenging a player, progress update of a game
+    // has to be relayed to all users who are currently online
+    // these events are communicated by the application via this channel to webwocket handler
     let (sender, receiver) = tokio::sync::mpsc::channel::<UiMessage>(32);
     let app = Arc::new(Mutex::new(App::new(sender)));
 


### PR DESCRIPTION
This PR will add the support to queue events and display them on the bottom bar.

The display of events will vary based on their age. 
- If they have been displayed new, then there will be a bold modifier to it, 
- If the age is greater than 75% then, no modifier will be applied
- Otherwise DIM modifier will be applied

a field named `displayed_at` is added to the event. This will track the time at which the event was displayed.
It is the developers responsibility to update the displayed at time.

